### PR TITLE
feat: updated securities for accessing AZURE_CLIENT_SECRET

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-* @obs-gh-colinhutchinson @yasar-observe
+* @obs-gh-nikhildua
+

--- a/main.bicep
+++ b/main.bicep
@@ -8,7 +8,7 @@ param observe_token string
 param observe_domain string = 'observeinc.com'
 param timer_resources_func_schedule string = '0 */10 * * * *'
 param timer_vm_metrics_func_schedule string = '30 */5 * * * *'
-param func_url string = 'https://observeinc.s3.us-west-2.amazonaws.com/azure/azure-collection-functions-v0.7.0.zip'
+param func_url string = 'https://observeinc.s3.us-west-2.amazonaws.com/azure/azure-collection-functions-v0.10.0.zip'
 param location string = deployment().location
 param location_abbreviation object = {
   australiacentral: 'ac'

--- a/services.bicep
+++ b/services.bicep
@@ -72,7 +72,7 @@ resource key_vault 'Microsoft.KeyVault/vaults@2022-07-01' = {
   }
 
   resource azurerm_key_vault_secret_observe_password 'secrets@2022-07-01' = {
-    name: 'observe-passsword'
+    name: 'observe-password'
     properties: {
       value: clientSecretValue
     }

--- a/services.bicep
+++ b/services.bicep
@@ -70,7 +70,17 @@ resource key_vault 'Microsoft.KeyVault/vaults@2022-07-01' = {
       value: observe_token
     }
   }
+
+  resource azurerm_key_vault_secret_observe_password 'secrets@2022-07-01' = {
+    name: 'observe-passsword'
+    properties: {
+      value: clientSecretValue
+    }
+  }
+
 }
+
+
 
 // EventHub
 // https://learn.microsoft.com/en-us/azure/templates/microsoft.eventhub/namespaces?pivots=deployment-language-bicep
@@ -175,7 +185,7 @@ resource website 'Microsoft.Web/sites@2022-03-01' = {
         { name: 'OBSERVE_TOKEN', value: '@Microsoft.KeyVault(SecretUri=https://${keyvault_name}.vault.azure.net/secrets/observe-token/)' }
         { name: 'AZURE_TENANT_ID', value: tenant().tenantId }
         { name: 'AZURE_CLIENT_ID', value: applicationId }
-        { name: 'AZURE_CLIENT_SECRET', value: clientSecretValue }
+        { name: 'AZURE_CLIENT_SECRET', value: '@Microsoft.KeyVault(SecretUri=https://${keyvault_name}.vault.azure.net/secrets/observe-password/)' }
         { name: 'AZURE_CLIENT_LOCATION', value: toLower(replace(location, ' ', '')) }
         { name: 'timer_resources_func_schedule', value: timer_resources_func_schedule }
         { name: 'timer_vm_metrics_func_schedule', value: timer_vm_metrics_func_schedule }


### PR DESCRIPTION
Updates AZURE_CLIENT_SECRET in function app to refer to key_vault:

```
 AZURE_CLIENT_SECRET= "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.observe_password.id})"

```

Tested in Content Eng Subscription via ARM 

<img width="1227" alt="Screenshot 2024-01-16 at 12 00 56 PM" src="https://github.com/observeinc/resourcemanager-azure-collection/assets/124205220/de6d25bf-7661-4316-8fb9-5502d06795e5">
